### PR TITLE
Rules groupped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2016-12-29 - Release 2.2.0
+### Summary
+Small feature release.
+
+#### Features
+- Merge [Pull #21](https://github.com/kemra102/puppet-auditd/pull/21): Added support for `write_logs` option for `auditd` versions `>= 2.5.2`. 
+
 ## 2016-11-25 - Release 2.1.0
 ### Summary
 Various bug fixes.

--- a/README.md
+++ b/README.md
@@ -277,6 +277,12 @@ This  keyword  specifies  the  group  that is applied to the log file's permissi
 
 Default: `root`
 
+#### `write_logs`
+
+This yes/no keyword determines whether or not to write logs to the disk. There are two options: yes and no. It is meant to replace the usage of `log_format = NOLOG`. This will default to undef since it is only available in version >= 2.5.2.
+
+Default: `undef`
+
 #### `priority_boost`
 
 This is a non-negative number that tells the audit damon how much of a priority boost it should take. The default is 3. No change is 0.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,12 @@
 #   permissions. The default is root. The group name can be either numeric
 #   or spelled out.
 #
+# [*write_logs*]
+#   This yes/no keyword determines whether or not to write logs to the disk.
+#   There are two options: yes and no. It is meant to replace the usage of
+#   log_format = NOLOG. This will default to undef since it is only available
+#   in version >= 2.5.2.
+#
 # [*priority_boost*]
 #   This is a non-negative number that tells the audit damon how much of
 #   a priority boost it should take. The default is 3. No change is 0.
@@ -321,6 +327,7 @@ class auditd (
   $log_file                = $::auditd::params::log_file,
   $log_format              = $::auditd::params::log_format,
   $log_group               = $::auditd::params::log_group,
+  $write_logs              = $::auditd::params::write_logs,
   $priority_boost          = $::auditd::params::priority_boost,
   $flush                   = $::auditd::params::flush,
   $freq                    = $::auditd::params::freq,
@@ -379,6 +386,10 @@ class auditd (
   validate_re($log_format, '^(RAW|NOLOG)$',
     "${log_format} is not supported for log_format. Allowed values are 'RAW' and 'NOLOG'.")
   validate_string($log_group)
+  if $write_logs != undef {
+    validate_re($write_logs, '^(yes|no)$',
+      "${write_logs} is not supported for write_logs. Allowed values are 'yes' and 'no'.")
+  }
   validate_integer($priority_boost)
   validate_re($flush, '^(none|incremental|data|sync)$',
     "${flush} is not supported for flush. Allowed values are 'none', 'incremental', 'data' and 'sync'.")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -235,10 +235,19 @@
 #
 # [*rules_file*]
 #   Location of the Audit rules file.
+# 
+# [*rules_group*]
+#   Array containing the name of files where will be store audit's rules.
+# 
+# [*rule_groups_path*]
+#   Location of the Audit's rules directory by default is /etc/audit/rules.d/.
 #
 # [*manage_audit_files*]
 #   On systems with 'rules.d' directory whether or not to manage that directory
 #   removing rules not managed by Puppet.
+#
+# [*manage_rules_group*]
+#   Disable puppet.rules creation and enable *rules_group* for group Audit rules.
 #
 # [*buffer_size*]
 #   Sets the buffer size used by Auditd.
@@ -356,6 +365,9 @@ class auditd (
 
   # Variables for Audit files
   $rules_file              = $::auditd::params::rules_file,
+  $rule_groups             = $::auditd::params::rule_groups,
+  $rule_groups_path        = $::auditd::params::rule_groups_path,
+  $manage_rules_group      = $::auditd::params::manage_rules_group,
   $manage_audit_files      = $::auditd::params::manage_audit_files,
   $buffer_size             = $::auditd::params::buffer_size,
 
@@ -434,7 +446,12 @@ class auditd (
   }
 
   validate_absolute_path($rules_file)
+  validate_absolute_path($rule_groups_path)
+  $rule_groups.each | String $file | {
+    validate_string($file)
+  }
   validate_bool($manage_audit_files)
+  validate_bool($manage_rules_group)
   validate_integer($buffer_size)
 
   validate_integer($audisp_q_depth)
@@ -453,14 +470,26 @@ class auditd (
   validate_bool($service_enable)
 
   # Install package
-  package { $package_name:
-    ensure => 'present',
-    alias  => 'auditd',
-    before => [
-      File['/etc/audit/auditd.conf'],
-      File['/etc/audisp/audispd.conf'],
-      Concat['audit-file'],
-    ],
+  
+  if ! $manage_rules_group {
+    package { $package_name:
+      ensure => 'present',
+      alias  => 'auditd',
+      before => [
+        File['/etc/audit/auditd.conf'],
+        File['/etc/audisp/audispd.conf'],
+        Concat['audit-file'],
+      ]
+    }
+  }else{
+    package { $package_name:
+      ensure => 'present',
+      alias  => 'auditd',
+      before => [
+        File['/etc/audit/auditd.conf'],
+        File['/etc/audisp/audispd.conf'],
+      ]
+    }
   }
 
   # Configure required config files
@@ -482,20 +511,42 @@ class auditd (
       require => Package[$package_name],
     }
   }
-  concat { $rules_file:
-    ensure         => 'present',
-    owner          => 'root',
-    group          => 'root',
-    mode           => '0640',
-    ensure_newline => true,
-    warn           => true,
-    alias          => 'audit-file',
+  if ! $manage_rules_group { 
+    concat { $rules_file:
+      ensure         => 'present',
+      owner          => 'root',
+      group          => 'root',
+      mode           => '0640',
+      ensure_newline => true,
+      warn           => true,
+      alias          => 'audit-file',
+    }
+
+    concat::fragment{ 'auditd_rules_begin':
+      target  => $rules_file,
+      content => template('auditd/audit.rules.begin.fragment.erb'),
+      order   => 0
+    }
   }
-  concat::fragment{ 'auditd_rules_begin':
-    target  => $rules_file,
-    content => template('auditd/audit.rules.begin.fragment.erb'),
-    order   => 0
+  if $manage_rules_group { 
+    $rule_groups.each | String $grfile | {
+      concat { "${rule_groups_path}${grfile}":
+        ensure         => 'present',
+        owner          => 'root',
+        group          => 'root',
+        mode           => '0640',
+        ensure_newline => true,
+        warn           => true,
+        alias          => $grfile,
+      }
+      concat::fragment { "auditd_rules_group_begin_${grfile}":
+        target  => "${rule_groups_path}${grfile}",
+        content => template('auditd/audit.rules.begin.fragment.erb'),
+        order   =>  0,
+      }
+    }
   }
+
   file { '/etc/audisp/audispd.conf':
     ensure  => 'file',
     owner   => 'root',
@@ -510,6 +561,15 @@ class auditd (
   }
 
   # Manage the service
+  $subscribe = [ File['/etc/audit/auditd.conf'],File['/etc/audisp/audispd.conf'] ]
+  if $manage_service and ! $rule_groups_path {
+    $subscribe = $subscribe + Concat['audit-file']
+  }else{
+    $rule_groups.each | String $file | {
+      $subscribe = $subscribe + Concat[$file]
+    }
+  }
+
   if $manage_service {
     service { 'auditd':
       ensure    => $service_ensure,
@@ -517,12 +577,7 @@ class auditd (
       hasstatus => true,
       restart   => $service_restart,
       stop      => $service_stop,
-      subscribe => [
-        File['/etc/audit/auditd.conf'],
-        File['/etc/audisp/audispd.conf'],
-        Concat['audit-file'],
-      ],
+      subscribe => $subscribe
     }
   }
-
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -76,6 +76,7 @@ class auditd::params {
   $log_file                = '/var/log/audit/audit.log'
   $log_format              = 'RAW'
   $log_group               = 'root'
+  $write_logs              = undef
   $priority_boost          = '4'
   $flush                   = 'incremental'
   $freq                    = '20'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,6 @@
 class auditd::params {
 
+
   # OS specific variables.
   case $::osfamily {
     'Debian': {
@@ -25,6 +26,9 @@ class auditd::params {
         $audisp_package     = 'audit-audispd-plugins'
         $manage_audit_files = true
         $rules_file         = '/etc/audit/rules.d/puppet.rules'
+        $rule_groups             = undef
+        $manage_rules_group      = false 
+        $rule_groups_path        = '/etc/audit/rules.d/'
         $service_restart    = '/bin/systemctl restart auditd'
         $service_stop       = '/bin/systemctl stop auditd'
       }
@@ -43,6 +47,9 @@ class auditd::params {
 
       if $::operatingsystem != 'Amazon' and versioncmp($::operatingsystemrelease, '7') >= 0 {
         $rules_file      = '/etc/audit/rules.d/puppet.rules'
+        $rule_groups             = undef
+        $manage_rules_group      = false 
+        $rule_groups_path        = '/etc/audit/rules.d/'
         $service_restart = '/usr/libexec/initscripts/legacy-actions/auditd/restart'
         $service_stop    = '/usr/libexec/initscripts/legacy-actions/auditd/stop'
       } else {
@@ -102,6 +109,7 @@ class auditd::params {
   $enable_krb5             = 'no'
   $krb5_principal          = 'auditd'
   $krb5_key_file           = undef
+
 
   # Rules Header variables
   $buffer_size = '8192'

--- a/manifests/rule.pp
+++ b/manifests/rule.pp
@@ -2,7 +2,7 @@
 ##    content: Rule definition
 ##    order:   Relative order of this rule
 
-define auditd::rule($content='', $order=10) {
+define auditd::rule($content='', $order=10, $rules_group='') {
   if $content == '' {
     $body = $name
   } else {
@@ -11,10 +11,20 @@ define auditd::rule($content='', $order=10) {
 
   validate_numeric($order)
   validate_string($body)
+  validate_string($rules_group)
 
-  concat::fragment{ "auditd_fragment_${name}":
-    target  => $auditd::params::rules_file,
-    order   => $order,
-    content => $body,
+  if $rules_group == '' {
+    concat::fragment{ "auditd_fragment_${name}":
+      target  => $auditd::params::rules_file,
+      order   => $order,
+      content => $body,
+    }
+  }else {
+    concat::fragment { "auditd_fragment_${rules_group}_${name}" :
+      target  => "${auditd::params::rule_groups_path}${rules_group}",
+      order   => $order,
+      content => $body,
+    }
   }
+
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "kemra102-auditd",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": "Danny Roberts",
   "summary": "Manage the audit daemon and it's rules.",
   "license": "BSD-2-Clause",

--- a/templates/auditd.conf.erb
+++ b/templates/auditd.conf.erb
@@ -4,6 +4,9 @@
 log_file = <%= @log_file %>
 log_format = <%= @log_format %>
 log_group = <%= @log_group %>
+<% unless @write_logs.nil? %>
+write_logs = <%= @write_logs %>
+<% end -%>
 priority_boost = <%= @priority_boost %>
 flush = <%= @flush %>
 freq = <%= @freq %>


### PR DESCRIPTION
I have implement the ability of grouping audit's rules in different files.
For the moment and with the version v2.2.0 this feature will work with RHEL OS family, but i'm tested only Centos7.
@kemra102 